### PR TITLE
Correct as-is in profiles

### DIFF
--- a/ODP-extract/ars-5.0-high-profile.xml
+++ b/ODP-extract/ars-5.0-high-profile.xml
@@ -448,7 +448,7 @@
         </include-controls>
     </import>
     <merge>
-        <as-is/>
+        <as-is>true</as-is>
     </merge>
     <modify>
         <set-parameter class="ODP" param-id="ac-1_prm_1">

--- a/ODP-extract/ars-5.0-hva-profile.xml
+++ b/ODP-extract/ars-5.0-hva-profile.xml
@@ -483,7 +483,7 @@
         </include-controls>
     </import>
     <merge>
-        <as-is/>
+        <as-is>true</as-is>
     </merge>
     <modify>
         <set-parameter class="ODP" param-id="ac-1_prm_1">

--- a/ODP-extract/ars-5.0-low-profile.xml
+++ b/ODP-extract/ars-5.0-low-profile.xml
@@ -198,7 +198,7 @@
         </include-controls>
     </import>
     <merge>
-        <as-is/>
+        <as-is>true</as-is>
     </merge>
     <modify>
         <set-parameter class="ODP" param-id="ac-1_prm_1">

--- a/ODP-extract/ars-5.0-moderate-profile.xml
+++ b/ODP-extract/ars-5.0-moderate-profile.xml
@@ -364,7 +364,7 @@
         </include-controls>
     </import>
     <merge>
-        <as-is/>
+        <as-is>true</as-is>
     </merge>
     <modify>
         <set-parameter class="ODP" param-id="ac-1_prm_1">


### PR DESCRIPTION
`as-is` was missing boolean content.